### PR TITLE
Updated the deployment  to work better with the upcoming demo in a box  scenario (splunk Show)

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -54,6 +54,8 @@ spec:
               value: "true"   
             - name: ENABLE_COPYRIGHT_CERTIFICATION
               value: "true"
+            - name: "STOCK_PHOTO_MAX_FINGERPRINT_SIZE"
+              value; 100000  
             - name: JAVA_TOOL_OPTIONS
               value: -javaagent:/opt/sfx/splunk-otel-javaagent-all.jar
           resources:

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -28,16 +28,8 @@ spec:
       terminationGracePeriodSeconds: 5
       tolerations:
       nodeSelector:
-      initContainers:
-        - name: sfx-instrumentation
-          image: quay.io/signalfuse/sfx-zero-config-agent:latest
-          # image: sfx-zero-config-agent
-          # imagePullPolicy: Never
-          volumeMounts:
-            - mountPath: /opt/sfx/
-              name: sfx-instrumentation
       containers:
-        - name: server
+        - name: adserver
           image: adservice
           ports:
             - containerPort: 9555
@@ -50,13 +42,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: OTEL_PROPAGATORS
+              value: "b3multi" 
             - name: OTEL_EXPORTER
               value: otlp
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(NODE_IP):4317
-          volumeMounts:
-            - mountPath: /opt/sfx
-              name: sfx-instrumentation
+            - name: SPLUNK_PROFILER_ENABLED
+              value: "true"
+            - name: SPLUNK_PROFILER_MEMORY_ENABLED
+              value: "true"   
+            - name: ENABLE_COPYRIGHT_CERTIFICATION
+              value: "true"
+            - name: JAVA_TOOL_OPTIONS
+              value: -javaagent:/opt/sfx/splunk-otel-javaagent-all.jar
           resources:
             requests:
               cpu: 200m

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -20,7 +20,7 @@ RUN apk --update add curl
 RUN mkdir -p /opt/sfx
 WORKDIR /opt/sfx
 
-RUN curl -L https://github.com/signalfx/splunk-otel-java/releases/download/v1.7.3/splunk-otel-javaagent-all.jar -o splunk-otel-javaagent-all.jar
+RUN curl -L https://github.com/signalfx/splunk-otel-java/releases/download/v1.11.0/splunk-otel-javaagent-all.jar -o splunk-otel-javaagent-all.jar
 
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:alpine-slim as base
+FROM adoptopenjdk/openjdk8:alpine as base
 
 FROM base as builder
 
@@ -15,6 +15,13 @@ RUN ./gradlew installDist
 
 FROM base 
 
+RUN apk --update add curl
+
+RUN mkdir -p /opt/sfx
+WORKDIR /opt/sfx
+
+RUN curl -L https://github.com/signalfx/splunk-otel-java/releases/download/v1.7.3/splunk-otel-javaagent-all.jar -o splunk-otel-javaagent-all.jar
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
@@ -23,7 +30,7 @@ WORKDIR /app
 COPY --from=builder /app .
 
 # Allow bottlenecks via copyright certification
-ENV ENABLE_COPYRIGHT_CERTIFICATION=true
+#ENV ENABLE_COPYRIGHT_CERTIFICATION=true
 
 EXPOSE 9555
 ENTRYPOINT ["/app/build/install/AdService/bin/AdService"]

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,7 +45,7 @@ dependencies {
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.43.Final"
 
-        javaagent "com.splunk:splunk-otel-javaagent:1.6.0:all"
+        javaagent "com.splunk:splunk-otel-javaagent:1.11.0:all"
     }
 }
 

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -39,7 +39,7 @@ dependencies {
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
                 "javax.annotation:javax.annotation-api:1.3.2",
-                "org.apache.logging.log4j:log4j-core:2.15.0"
+                "org.apache.logging.log4j:log4j-core:2.17.1"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",

--- a/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
@@ -20,7 +20,7 @@ public class CopyrightCertification {
     public List<hipstershop.Demo.Ad> certify(String category, List<hipstershop.Demo.Ad> ads) {
         if(!enabled){
             return ads;
-        }
+         }
         Certifier certifier = certifiers.get(category);
         return certifier.certify(ads);
     }

--- a/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
@@ -1,10 +1,14 @@
 package hipstershop.copyright;
 
+import hipstershop.AdService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CopyrightCertification {
+    private static final Logger logger = LogManager.getLogger(AdService.class);
 
     private final Map<String, Certifier> certifiers = new HashMap<>();
     private final boolean enabled = Boolean.parseBoolean(System.getenv().getOrDefault("ENABLE_COPYRIGHT_CERTIFICATION", "false"));
@@ -20,8 +24,11 @@ public class CopyrightCertification {
     public List<hipstershop.Demo.Ad> certify(String category, List<hipstershop.Demo.Ad> ads) {
         if(!enabled){
             return ads;
+
          }
+        logger.info("Getting ads for category: {}", category);
         Certifier certifier = certifiers.get(category);
-        return certifier.certify(ads);
+
+        return certifier != null ? certifier.certify(ads) : ads;
     }
 }

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -45,9 +45,12 @@ public class StockPhotos {
         private final byte[] photoFingerprint;
         private static final int MAX_FINGERPRINT_SIZE = Integer.parseInt(System.getenv().getOrDefault("STOCK_PHOTO_MAX_FINGERPRINT_SIZE", "1000000"));
 
+        static {
+            logger.info("photo size selected : {}", MAX_FINGERPRINT_SIZE);
+        }
+
         public CopyrightPhoto(String id) {
             this.id = id;
-            logger.info("photo size selected : %d",MAX_FINGERPRINT_SIZE);   
             photoFingerprint = new byte[new Random().nextInt(MAX_FINGERPRINT_SIZE)];
         }
 

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -46,7 +46,7 @@ public class StockPhotos {
 
         public CopyrightPhoto(String id) {
             this.id = id;
-            photoFingerprint = new byte[new Random().nextInt(1_000_000)];
+            photoFingerprint = new byte[new Random().nextInt(500_000)];
         }
 
         public boolean matchesAd(Demo.Ad ad) {

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -2,6 +2,7 @@ package hipstershop.copyright;
 
 import hipstershop.AdService;
 import hipstershop.Demo;
+import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -12,14 +13,13 @@ import java.util.List;
 public class StockPhotos {
 
     private final static long MAX_TIME_MS = 6500;
-    private final static List<CopyrightPhoto> photos = createDatabase();
     private static final Logger logger = LogManager.getLogger(AdService.class);
 
     boolean isCopyright(Demo.Ad ad){
         boolean result = true;
         logger.info("Copyright check");
         long start = System.currentTimeMillis();
-        for (CopyrightPhoto photo : photos) {
+        for (CopyrightPhoto photo : createDatabase()) {
             if(photo.matchesAd(ad)){
                 result = false;
             }
@@ -42,15 +42,17 @@ public class StockPhotos {
     static class CopyrightPhoto {
 
         private final String id;
+        private final byte[] photoFingerprint;
 
         public CopyrightPhoto(String id) {
             this.id = id;
+            photoFingerprint = new byte[new Random().nextInt(1_000_000)];
         }
 
         public boolean matchesAd(Demo.Ad ad) {
             boolean matches = false;
-            for (CopyrightPhoto photo : photos) {
-                if(photo.id.equals(ad.getRedirectUrl())){
+            for (CopyrightPhoto photo : createDatabase()) {
+                if(photo.id.equals(ad.getRedirectUrl())) {
                     matches = true;
                 }
             }

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -17,6 +17,7 @@ public class StockPhotos {
 
     boolean isCopyright(Demo.Ad ad){
         boolean result = true;
+        logger.info("Copyright check");
         long start = System.currentTimeMillis();
         for (CopyrightPhoto photo : photos) {
             if(photo.matchesAd(ad)){

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -43,10 +43,11 @@ public class StockPhotos {
 
         private final String id;
         private final byte[] photoFingerprint;
+        private static final int MAX_FINGERPRINT_SIZE = Integer.parseInt(System.getenv().getOrDefault("STOCK_PHOTO_MAX_FINGERPRINT_SIZE", "1000000"));
 
         public CopyrightPhoto(String id) {
             this.id = id;
-            photoFingerprint = new byte[new Random().nextInt(500_000)];
+            photoFingerprint = new byte[new Random().nextInt(MAX_FINGERPRINT_SIZE)];
         }
 
         public boolean matchesAd(Demo.Ad ad) {

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -47,6 +47,7 @@ public class StockPhotos {
 
         public CopyrightPhoto(String id) {
             this.id = id;
+            logger.info("photo size selected : %d",MAX_FINGERPRINT_SIZE);   
             photoFingerprint = new byte[new Random().nextInt(MAX_FINGERPRINT_SIZE)];
         }
 

--- a/src/adservice/src/main/resources/log4j2.xml
+++ b/src/adservice/src/main/resources/log4j2.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-  <Appenders>
-    <Console name="STDOUT" target="SYSTEM_OUT">
-
-      <!-- This is a JSON appender adds additional fields to logs for logs-traces correlation: 
-           trace ID, span ID, and flag showing sampling decision. -->
-
-      <JsonLayout compact="true" eventEol="true">
-        <KeyValuePair key="trace_id" value="$${ctx:traceId}"/>
-        <KeyValuePair key="span_id" value="$${ctx:spanId}"/>
-        <KeyValuePair key="service.name" value="$${env:OTEL_EXPORTER_ZIPKIN_SERVICE_NAME}"/>
-        <KeyValuePair key="trace_sampled" value="$${ctx:sampled}"/>
-     </JsonLayout>
-
-    </Console>
+  <Appenders> 
+     <Console name="STDOUT" target="SYSTEM_OUT">
+        <JsonLayout compact="true" eventEol="true">
+           <KeyValuePair key="trace_id" value="${ctx:trace_id}"/>
+           <KeyValuePair key="span_id" value="${ctx:span_id}"/>
+           <KeyValuePair key="service.name" value="${sys:otel.resource.service.name}"/>
+           <KeyValuePair key="trace_sampled" value="${ctx:trace_flags}"/>
+        </JsonLayout>
+     </Console>
   </Appenders>
   <Loggers>
     <Logger name="io.grpc.netty" level="INFO"/>


### PR DESCRIPTION
I've  changed the following to the ad service:

-  removed the requirement to rely on the external auto instrumentation library and embedded version 1.7.4 inside the ad service container 
- commented out the env variable that set the copyright check and rely on the k8s manifest to set it correctly, allowing for enabling/disabling of the error
- Example manifest updated

This is now running as part of the demo in the box project en I'm trying to  promote the changes up to the sfx microservice repository
given, I'm not sure these changes are available in the main one yet, I decided to start here
 